### PR TITLE
npm bump ini

### DIFF
--- a/src/lib/package-lock.json
+++ b/src/lib/package-lock.json
@@ -13,6 +13,7 @@
         "ajv": "^8.12.0",
         "braces": "^3.0.2",
         "cached-path-relative": "^1.1.0",
+        "ini": "^4.1.2",
         "js-yaml": "^3.13.1",
         "kind-of": "^6.0.3"
       },
@@ -3165,6 +3166,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/global-prefix/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
     "node_modules/globals": {
       "version": "11.7.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
@@ -3967,10 +3974,12 @@
       "dev": true
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/inline-source-map": {
       "version": "0.6.2",
@@ -9592,6 +9601,14 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+          "dev": true
+        }
       }
     },
     "globals": {
@@ -10239,10 +10256,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+      "integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw=="
     },
     "inline-source-map": {
       "version": "0.6.2",

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -31,6 +31,7 @@
     "ajv": "^8.12.0",
     "braces": "^3.0.2",
     "cached-path-relative": "^1.1.0",
+    "ini": "^4.1.2",
     "js-yaml": "^3.13.1",
     "kind-of": "^6.0.3"
   }


### PR DESCRIPTION
**security alert:**  ini before 1.3.6 vulnerable to Prototype Pollution via ini.parse

1.  npm uninstall ini

1.  reinstall

1.  verify updated version as listed in package.json 
> "ini": "^4.1.2",