### PR TITLE
npm bump minimist

### DIFF
--- a/src/lib/package-lock.json
+++ b/src/lib/package-lock.json
@@ -15,7 +15,8 @@
         "cached-path-relative": "^1.1.0",
         "ini": "^4.1.2",
         "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.3"
+        "kind-of": "^6.0.3",
+        "minimist": "^1.2.8"
       },
       "devDependencies": {
         "grunt": "^1.5.3",
@@ -4888,7 +4889,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11006,8 +11006,7 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mixin-deep": {
       "version": "1.3.2",

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -33,6 +33,7 @@
     "cached-path-relative": "^1.1.0",
     "ini": "^4.1.2",
     "js-yaml": "^3.13.1",
-    "kind-of": "^6.0.3"
+    "kind-of": "^6.0.3",
+    "minimist": "^1.2.8"
   }
 }


### PR DESCRIPTION
security
Previous versions had a prototype pollution bug that could cause privilege escalation in some circumstances when handling untrusted user input.

Please use version 1.2.6 or later: